### PR TITLE
CIV-5336 Configmap for SOL did driver

### DIFF
--- a/ci/deploy-k8s-aws/app-specs/configmap-driver-did-sol.yaml
+++ b/ci/deploy-k8s-aws/app-specs/configmap-driver-did-sol.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-driver-did-sol
+data:
+  config.json: |
+    {
+      "solanaRpcNodes": {
+        "mainnet-beta": "https://rough-misty-night.solana-mainnet.quiknode.pro/b57300ff234c12e95763e9b8cda67e9d86772a0d",
+        "devnet": "https://rough-misty-night.solana-devnet.quiknode.pro/b57300ff234c12e95763e9b8cda67e9d86772a0d" 
+      }
+    }

--- a/ci/deploy-k8s-aws/scripts/k8s-template.yaml
+++ b/ci/deploy-k8s-aws/scripts/k8s-template.yaml
@@ -25,6 +25,8 @@ spec:
           capabilities:
             drop:
               - NET_RAW
+      {{configMapVolume}}
+
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Update the k8s `prepare-deployment.py` script as follows:
- Detect `configmap-<driver>.yaml` files, and add a `volumeMount` to `/usr/src/app` for all driver containers that have such a file defined.
Added an initial configmap for the SOL did driver, containing quiknode endpoints for devnet and mainnet-beta.
- Add a step to create the payer secret

