### PR TITLE
CIV-5336 Set fargate=true labels on deployments

### DIFF
--- a/ci/deploy-k8s-aws/app-specs/deployment-uni-resolver-frontend.yaml
+++ b/ci/deploy-k8s-aws/app-specs/deployment-uni-resolver-frontend.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: uni-resolver-frontend
+        fargate: "true"
     spec:
       containers:
       - name: uni-resolver-frontend

--- a/ci/deploy-k8s-aws/app-specs/deployment-uni-resolver-web.yaml
+++ b/ci/deploy-k8s-aws/app-specs/deployment-uni-resolver-web.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: uni-resolver-web
+        fargate: "true"
     spec:
       containers:
       - name: uni-resolver-web

--- a/ci/deploy-k8s-aws/scripts/k8s-template.yaml
+++ b/ci/deploy-k8s-aws/scripts/k8s-template.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{containerName}}
+        fargate: "true"
     spec:
       containers:
       - name: {{containerName}}


### PR DESCRIPTION
CIV-5336 Set fargate=true labels on deployments, so they will run on Fargate on the Civic EKS clusters.