### PR TITLE
CIV-5336 Support dev and prod clusters in k8s deployment workflow

### DIFF
--- a/.github/workflows/kubernetes-deploy-to-cluster.yml
+++ b/.github/workflows/kubernetes-deploy-to-cluster.yml
@@ -2,6 +2,11 @@ name: AWS Kubernetes deployment
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment ( dev / prod )'
+        required: true
+        default: 'dev'
 
 env:
   IMAGE_NAME: universalresolver/uni-resolver-web

--- a/.github/workflows/kubernetes-deploy-to-cluster.yml
+++ b/.github/workflows/kubernetes-deploy-to-cluster.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment ( dev / prod )'
+        type: choice
+        description: 'Environment ( Dev / Prod )'
         required: true
-        default: 'dev'
+        options:
+        - Dev
+        - Prod
+        default: 'Dev'
 
 env:
   IMAGE_NAME: universalresolver/uni-resolver-web
@@ -17,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: 
-      name: Dev
+      name: ${{ github.event.inputs.environment }}
     steps:
     - uses: actions/checkout@master
 

--- a/.github/workflows/kubernetes-deploy-to-cluster.yml
+++ b/.github/workflows/kubernetes-deploy-to-cluster.yml
@@ -31,6 +31,7 @@ jobs:
         KUBE_CONFIG_DATA: ${{secrets.KUBE_CONFIG_DATA}}
         AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
         AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+        ENVIRONMENT: ${{github.event.inputs.environment}}
         RPC_URL_TESTNET: ${{env.RPC_URL_TESTNET}}
         RPC_CERT_TESTNET: ${{env.RPC_CERT_TESTNET}}
     - name: Slack notification

--- a/ci/deploy-k8s-aws/scripts/entrypoint.sh
+++ b/ci/deploy-k8s-aws/scripts/entrypoint.sh
@@ -12,7 +12,7 @@ touch /tmp/kube/kubeconfig
 export KUBECONFIG=/tmp/kube/kubeconfig
 chmod 600 $KUBECONFIG
 
-if [ "$ENVIRONMENT" == "Prod"]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"
+if [ "$ENVIRONMENT" == "Prod"]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"; fi
 
 echo "ENVIRONMENT: $ENVIRONMENT"
 echo "CLUSTER: $CLUSTER"

--- a/ci/deploy-k8s-aws/scripts/entrypoint.sh
+++ b/ci/deploy-k8s-aws/scripts/entrypoint.sh
@@ -12,7 +12,7 @@ touch /tmp/kube/kubeconfig
 export KUBECONFIG=/tmp/kube/kubeconfig
 chmod 600 $KUBECONFIG
 
-if [ "$ENVIRONMENT" == 'Prod' ]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"; fi
+if [ "$ENVIRONMENT" = Prod ]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"; fi
 
 echo "ENVIRONMENT: $ENVIRONMENT"
 echo "CLUSTER: $CLUSTER"

--- a/ci/deploy-k8s-aws/scripts/entrypoint.sh
+++ b/ci/deploy-k8s-aws/scripts/entrypoint.sh
@@ -12,7 +12,7 @@ touch /tmp/kube/kubeconfig
 export KUBECONFIG=/tmp/kube/kubeconfig
 chmod 600 $KUBECONFIG
 
-if [ "$ENVIRONMENT" == "Prod"]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"; fi
+if [ "$ENVIRONMENT" == "Prod" ]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"; fi
 
 echo "ENVIRONMENT: $ENVIRONMENT"
 echo "CLUSTER: $CLUSTER"

--- a/ci/deploy-k8s-aws/scripts/entrypoint.sh
+++ b/ci/deploy-k8s-aws/scripts/entrypoint.sh
@@ -7,7 +7,9 @@ set -e
 echo "## Root folder ##"
 ls -al /
 
-export KUBECONFIG=/tmp/config
+mkdir -p /tmp/kube
+touch /tmp/kube/kubeconfig
+export KUBECONFIG=/tmp/kube/kubeconfig
 chmod 600 $KUBECONFIG
 
 if [ "$ENVIRONMENT" == "Prod"]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"

--- a/ci/deploy-k8s-aws/scripts/entrypoint.sh
+++ b/ci/deploy-k8s-aws/scripts/entrypoint.sh
@@ -12,7 +12,7 @@ touch /tmp/kube/kubeconfig
 export KUBECONFIG=/tmp/kube/kubeconfig
 chmod 600 $KUBECONFIG
 
-if [ "$ENVIRONMENT" == "Prod" ]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"; fi
+if [ "$ENVIRONMENT" == 'Prod' ]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"; fi
 
 echo "ENVIRONMENT: $ENVIRONMENT"
 echo "CLUSTER: $CLUSTER"

--- a/ci/deploy-k8s-aws/scripts/entrypoint.sh
+++ b/ci/deploy-k8s-aws/scripts/entrypoint.sh
@@ -7,8 +7,15 @@ set -e
 echo "## Root folder ##"
 ls -al /
 
-echo "$KUBE_CONFIG_DATA" | base64 --decode > /tmp/config
 export KUBECONFIG=/tmp/config
+chmod 600 $KUBECONFIG
+
+if [ "$ENVIRONMENT" == "Prod"]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"
+
+echo "ENVIRONMENT: $ENVIRONMENT"
+echo "CLUSTER: $CLUSTER"
+
+aws eks --region us-east-1 update-kubeconfig --name $CLUSTER
 
 echo "## Kubeconfig ##"
 kubectl config view


### PR DESCRIPTION
Update the CI job called "AWS Kubernetes Deployment" so that it can be run for either the Dev or Prod cluster:
<img width="450" alt="Screenshot 2022-08-22 at 09 17 42" src="https://user-images.githubusercontent.com/30459645/185890406-f413a0ba-a1d5-4fef-bcb6-e3b0c72210d4.png">
