### PR TITLE
CIV-5336 Make ingress domain dymanic based on environment during k8s deployment

### DIFF
--- a/ci/deploy-k8s-aws/scripts/entrypoint.sh
+++ b/ci/deploy-k8s-aws/scripts/entrypoint.sh
@@ -13,9 +13,12 @@ export KUBECONFIG=/tmp/kube/kubeconfig
 chmod 600 $KUBECONFIG
 
 if [ "$ENVIRONMENT" = Prod ]; then export CLUSTER="civic-prod"; else export CLUSTER="civic-dev"; fi
+if [ "$ENVIRONMENT" = Prod ]; then export DEPLOYMENT_DOMAIN="did.civic.com"; else export DEPLOYMENT_DOMAIN="did-dev.civic.com"; fi
+
 
 echo "ENVIRONMENT: $ENVIRONMENT"
 echo "CLUSTER: $CLUSTER"
+echo "DEPLOYMENT_DOMAIN: $DEPLOYMENT_DOMAIN"
 
 aws eks --region us-east-1 update-kubeconfig --name $CLUSTER
 
@@ -28,7 +31,7 @@ echo "Current workspace Folder"
 pwd
 ls -al .
 python --version
-python prepare-deployment.py
+python prepare-deployment.py -d $DEPLOYMENT_DOMAIN
 
 echo "Driver config script"
 python driver-config.py

--- a/ci/deploy-k8s-aws/scripts/prepare-deployment.py
+++ b/ci/deploy-k8s-aws/scripts/prepare-deployment.py
@@ -129,8 +129,7 @@ def get_container_tags(containers):
     return container_tags
 
 
-def generate_ingress(containers, outputdir):
-    global DEFAULT_DOMAIN_NAME
+def generate_ingress(containers, outputdir, deploymentdomain):
     print("Generating uni-resolver-ingress.yaml")
     fout = open(outputdir + '/uni-resolver-ingress.yaml', "wt")
     fout.write('apiVersion: networking.k8s.io/v1\n')
@@ -148,7 +147,7 @@ def generate_ingress(containers, outputdir):
     fout.write('    app: \"uni-resolver-web\"\n')
     fout.write('spec:\n')
     fout.write('  rules:\n')
-    fout.write('    - host: ' + DEFAULT_DOMAIN_NAME + '\n')
+    fout.write('    - host: ' + deploymentdomain + '\n')
     fout.write('      http:\n')
     fout.write('        paths:\n')
     fout.write('          - path: /()(1.0/.*)\n')
@@ -222,22 +221,26 @@ def main(argv):
 
     compose = 'docker-compose.yml'
     outputdir = './deploy'
+    deploymentdomain = DEFAULT_DOMAIN_NAME
     try:
-        opts, args = getopt.getopt(argv, "hi:o:", ["compose=", "outputdir="])
+        opts, args = getopt.getopt(argv, "hi:o:d:", ["compose=", "outputdir=", "deploymentdomain="])
     except getopt.GetoptError:
-        print('./prepare-deployment.py -i <inputfile> -o <outputdir>')
+        print('./prepare-deployment.py -i <inputfile> -o <outputdir> -d <deploymentdomain>')
         sys.exit(2)
     for opt, arg in opts:
         if opt == '-h':
-            print('./prepare-deployment.py -i <inputfile> -o <outputdir>')
+            print('./prepare-deployment.py -i <inputfile> -o <outputdir> -d <deploymentdomain>')
             sys.exit()
         elif opt in ("-i", "--compose"):
             compose = arg
         elif opt in ("-o", "--outputdir"):
             outputdir = arg
+        elif opt in ("-d", "--deploymentdomain"):
+            deploymentdomain = arg
 
     print('Input file is:', compose)
     print('Output dir is:', outputdir)
+    print('Deployment domain is:', deploymentdomain)
 
     init_deployment_dir(outputdir)
 
@@ -245,7 +248,7 @@ def main(argv):
     print("Containers:")
     print(containers)
 
-    generate_ingress(containers, outputdir)
+    generate_ingress(containers, outputdir, deploymentdomain)
 
     # Payer key for the sol did driver:
     # NOTE: Before running this, the real key should be put into the yaml file.


### PR DESCRIPTION
The prepare-deployment.py script will now use the correct ingress host based on the environment:
`Dev` : `did-dev.civic.com`
`Prod` : `did.civic.com`