### PR TITLE
CM-1371 - Fix resources requests to match limits in deployments to work on Fargate

### DIFF
--- a/ci/deploy-k8s-aws/scripts/k8s-template.yaml
+++ b/ci/deploy-k8s-aws/scripts/k8s-template.yaml
@@ -21,9 +21,15 @@ spec:
         image: {{containerTag}}
         imagePullPolicy: Always
         resources:
+          # Since Amazon EKS Fargate runs only one pod per node,
+          # all Amazon EKS Fargate pods run with guaranteed priority,
+          # so the requested CPU and memory must be equal to the limit.
+          # Reference: https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html
           requests:
-            memory: "128Mi"
-            cpu: "5m"
+            memory: "512Mi"
+            cpu: "500m"
+          # memory: "128Mi"
+          # cpu: "5m"
           limits:
             memory: "512Mi"
             cpu: "500m"


### PR DESCRIPTION
Since cluster is running kubernetes v1.23, the values in the _resources.requests_ must match what _resources.limits_ for pods running on Fargate. This PR is fixing it as a preparation for v1.23 upgrade.

From [the documentation](https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html):
> Since Amazon EKS Fargate runs only one pod per node, the scenario of evicting pods in case of fewer resources doesn't occur. All Amazon EKS Fargate pods run with guaranteed priority, so the requested CPU and memory must be equal to the limit for all of the containers.
